### PR TITLE
fix: region 코드 오류 및 genre 필터 버그 3종 수정

### DIFF
--- a/src/features/genre-filter/genre-slug.ts
+++ b/src/features/genre-filter/genre-slug.ts
@@ -1,5 +1,5 @@
 /** KOPIS genrenm 값 → URL-safe 영어 slug 매핑 */
-const GENRE_TO_SLUG: Record<string, string> = {
+export const GENRE_TO_SLUG: Record<string, string> = {
   연극: 'play',
   뮤지컬: 'musical',
   '무용(서양/한국무용)': 'dance',

--- a/src/features/genre-filter/index.ts
+++ b/src/features/genre-filter/index.ts
@@ -1,2 +1,2 @@
 export { GenreFilter, getUniqueGenres, filterByGenre } from './genre-filter';
-export { genreToSlug, slugToGenre } from './genre-slug';
+export { genreToSlug, slugToGenre, GENRE_TO_SLUG } from './genre-slug';

--- a/src/features/region-filter/region-filter.tsx
+++ b/src/features/region-filter/region-filter.tsx
@@ -2,25 +2,25 @@
 
 import { filterBtnClass } from "@/shared/ui/button-class";
 
-// 지역 코드 → 표시명 매핑 (KOPIS signgucode 기준)
+// 지역 코드 → 표시명 매핑 (KOPIS signgucode = 법정동코드 앞 2자리)
 export const REGION_OPTIONS = [
   { code: "11", label: "서울" },
-  { code: "21", label: "부산" },
-  { code: "22", label: "대구" },
-  { code: "23", label: "인천" },
-  { code: "24", label: "광주" },
-  { code: "25", label: "대전" },
-  { code: "26", label: "울산" },
-  { code: "29", label: "세종" },
-  { code: "31", label: "경기" },
-  { code: "32", label: "강원" },
-  { code: "33", label: "충북" },
-  { code: "34", label: "충남" },
-  { code: "35", label: "전북" },
-  { code: "36", label: "전남" },
-  { code: "37", label: "경북" },
-  { code: "38", label: "경남" },
-  { code: "39", label: "제주" },
+  { code: "26", label: "부산" },
+  { code: "27", label: "대구" },
+  { code: "28", label: "인천" },
+  { code: "29", label: "광주" },
+  { code: "30", label: "대전" },
+  { code: "31", label: "울산" },
+  { code: "36", label: "세종" },
+  { code: "41", label: "경기" },
+  { code: "42", label: "강원" },
+  { code: "43", label: "충북" },
+  { code: "44", label: "충남" },
+  { code: "45", label: "전북" },
+  { code: "46", label: "전남" },
+  { code: "47", label: "경북" },
+  { code: "48", label: "경남" },
+  { code: "50", label: "제주" },
 ] as const;
 
 interface Props {

--- a/src/widgets/performance-list/performance-list.tsx
+++ b/src/widgets/performance-list/performance-list.tsx
@@ -8,9 +8,12 @@ import {
 } from "@/entities/performance";
 import {
   GenreFilter,
-  getUniqueGenres,
   filterByGenre,
+  GENRE_TO_SLUG,
 } from "@/features/genre-filter";
+
+// region이 바뀌어도 항상 고정 표시할 장르 목록
+const FIXED_GENRES = Object.keys(GENRE_TO_SLUG);
 import { RegionFilter } from "@/features/region-filter";
 import type { FetchPerformancesParams } from "@/shared";
 
@@ -38,10 +41,6 @@ export function PerformanceList({ params }: Props) {
   const { data, isPending, error, isError } = usePerformances(queryParams);
 
   const list = useMemo<Performance[]>(() => data ?? [], [data]);
-  const genres = useMemo(
-    () => getUniqueGenres(list.map((p) => p.genre)),
-    [list],
-  );
   const filtered = useMemo(
     () => filterByGenre(list, selectedGenre),
     [list, selectedGenre],
@@ -70,11 +69,10 @@ export function PerformanceList({ params }: Props) {
         onChange={(code) => {
           setSelectedRegion(code);
           setPage(1);
-          setSelectedGenre(null);
         }}
       />
       <GenreFilter
-        genres={genres}
+        genres={FIXED_GENRES}
         selected={selectedGenre}
         onChange={setSelectedGenre}
       />


### PR DESCRIPTION
## Summary
- region signgucode 법정동코드 기준으로 전면 수정 (기존 임의 번호 → 11=서울, 26=부산, 46=전남 등)
- region 변경 시 genre 선택 상태 유지 (setSelectedGenre(null) 제거)
- genre 필터를 GENRE_TO_SLUG 기반 고정 목록으로 변경 → region 무관하게 항상 동일한 버튼 표시

## Test plan
- [ ] 전남 선택 → 전라남도 공연 데이터 표시 확인
- [ ] genre 선택 후 region 변경 → genre 선택 상태 유지 확인
- [ ] region 변경 전후 genre 버튼 목록 동일함 확인

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)