### PR TITLE
fix: 장르 필터 서버사이드 전환으로 20개 페이지네이션 수정

### DIFF
--- a/src/features/genre-filter/genre-slug.ts
+++ b/src/features/genre-filter/genre-slug.ts
@@ -14,6 +14,18 @@ const SLUG_TO_GENRE: Record<string, string> = Object.fromEntries(
   Object.entries(GENRE_TO_SLUG).map(([genre, slug]) => [slug, genre]),
 );
 
+/** KOPIS genrenm 값 → KOPIS shcate 코드 매핑 */
+export const GENRE_TO_KOPIS_CODE: Record<string, string> = {
+  연극: 'AAAA',
+  뮤지컬: 'CCCG',
+  '무용(서양/한국무용)': 'BBBC',
+  '서양음악(클래식)': 'CCCA',
+  '한국음악(국악)': 'CCCD',
+  대중음악: 'GGGA',
+  '서커스/마술': 'EEEA',
+  복합: 'CCCH',
+};
+
 export function genreToSlug(genre: string): string {
   return GENRE_TO_SLUG[genre] ?? genre;
 }

--- a/src/features/genre-filter/index.ts
+++ b/src/features/genre-filter/index.ts
@@ -1,2 +1,2 @@
 export { GenreFilter, getUniqueGenres, filterByGenre } from './genre-filter';
-export { genreToSlug, slugToGenre, GENRE_TO_SLUG } from './genre-slug';
+export { genreToSlug, slugToGenre, GENRE_TO_SLUG, GENRE_TO_KOPIS_CODE } from './genre-slug';

--- a/src/shared/api/kopis.ts
+++ b/src/shared/api/kopis.ts
@@ -25,6 +25,7 @@ export interface FetchPerformancesParams {
   cpage?: number;
   rows?: number;
   signgucode?: string; // 지역 코드
+  shcate?: string; // 장르 코드 (AAAA=연극, CCCG=뮤지컬 등)
   prfstate?: '01' | '02' | '03'; // 01:예정 02:공연중 03:완료
 }
 
@@ -80,6 +81,7 @@ export async function fetchPerformances(
     cpage: String(params.cpage ?? 1),
     rows: String(params.rows ?? 20),
     ...(params.signgucode && { signgucode: params.signgucode }),
+    ...(params.shcate && { shcate: params.shcate }),
     ...(params.prfstate && { prfstate: params.prfstate }),
   });
 

--- a/src/widgets/performance-list/performance-list.tsx
+++ b/src/widgets/performance-list/performance-list.tsx
@@ -8,14 +8,14 @@ import {
 } from "@/entities/performance";
 import {
   GenreFilter,
-  filterByGenre,
   GENRE_TO_SLUG,
+  GENRE_TO_KOPIS_CODE,
 } from "@/features/genre-filter";
+import { RegionFilter } from "@/features/region-filter";
+import type { FetchPerformancesParams } from "@/shared";
 
 // region이 바뀌어도 항상 고정 표시할 장르 목록
 const FIXED_GENRES = Object.keys(GENRE_TO_SLUG);
-import { RegionFilter } from "@/features/region-filter";
-import type { FetchPerformancesParams } from "@/shared";
 
 const PAGE_SIZE = 20;
 
@@ -34,17 +34,15 @@ export function PerformanceList({ params }: Props) {
       cpage: page,
       rows: PAGE_SIZE,
       ...(selectedRegion && { signgucode: selectedRegion }),
+      // 장르 필터를 서버사이드로 전달 (클라이언트 필터링 대신 KOPIS shcate 사용)
+      ...(selectedGenre && { shcate: GENRE_TO_KOPIS_CODE[selectedGenre] }),
     }),
-    [params, page, selectedRegion],
+    [params, page, selectedRegion, selectedGenre],
   );
 
   const { data, isPending, error, isError } = usePerformances(queryParams);
 
   const list = useMemo<Performance[]>(() => data ?? [], [data]);
-  const filtered = useMemo(
-    () => filterByGenre(list, selectedGenre),
-    [list, selectedGenre],
-  );
 
   if (isPending) {
     return (
@@ -74,16 +72,19 @@ export function PerformanceList({ params }: Props) {
       <GenreFilter
         genres={FIXED_GENRES}
         selected={selectedGenre}
-        onChange={setSelectedGenre}
+        onChange={(genre) => {
+          setSelectedGenre(genre);
+          setPage(1);
+        }}
       />
 
-      {filtered.length === 0 ? (
+      {list.length === 0 ? (
         <div className="flex flex-1 items-center justify-center text-subtle">
           공연 정보가 없습니다.
         </div>
       ) : (
         <ul className="grid gap-3 p-4 sm:grid-cols-2 lg:grid-cols-3">
-          {filtered.map((performance) => (
+          {list.map((performance) => (
             <li key={performance.id}>
               <PerformanceCard performance={performance} />
             </li>


### PR DESCRIPTION
## Root Cause
장르 필터가 클라이언트사이드에서 20개 중 필터링 → 페이지당 2~3개만 표시

## Fix
KOPIS API `shcate` 파라미터로 장르 필터를 서버사이드로 이동

## Changes
- `GENRE_TO_KOPIS_CODE` 추가: genrenm → KOPIS shcate 코드 (AAAA, CCCG 등)
- `FetchPerformancesParams`에 `shcate` 추가
- `performance-list.tsx`: `filterByGenre` 제거, `shcate`를 queryParams에 포함
- 장르 변경 시 page 1 리셋 추가

## Test plan
- [ ] 뮤지컬 선택 → 20개 뮤지컬 공연 표시 확인
- [ ] 다음 페이지 → 20개 유지 확인
- [ ] 지역 + 장르 동시 선택 시 20개 유지 확인

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)