### PR TITLE
feat: 날짜 필터 구현 (이번 주/이번 달/다음 달)

### DIFF
--- a/src/features/date-filter/date-filter.tsx
+++ b/src/features/date-filter/date-filter.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { filterBtnClass } from "@/shared/ui/button-class";
+import type { DateRange } from "./date-filter.utils";
+
+const DATE_OPTIONS: { value: DateRange | null; label: string }[] = [
+  { value: null, label: "전체" },
+  { value: "week", label: "이번 주" },
+  { value: "month", label: "이번 달" },
+  { value: "next-month", label: "다음 달" },
+];
+
+interface Props {
+  selected: DateRange | null;
+  onChange: (range: DateRange | null) => void;
+}
+
+export function DateFilter({ selected, onChange }: Props) {
+  return (
+    <div className="flex flex-wrap gap-2 px-4 py-2">
+      {DATE_OPTIONS.map(({ value, label }) => (
+        <button
+          key={label}
+          type="button"
+          aria-pressed={selected === value}
+          onClick={() => onChange(value)}
+          className={filterBtnClass(selected === value)}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/features/date-filter/date-filter.utils.ts
+++ b/src/features/date-filter/date-filter.utils.ts
@@ -1,0 +1,27 @@
+export type DateRange = 'week' | 'month' | 'next-month';
+
+/** Date → YYYYMMDD 문자열 */
+function fmt(d: Date): string {
+  return `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** 선택한 DateRange에 맞는 stdate/eddate 반환 */
+export function getDateRangeParams(range: DateRange): { stdate: string; eddate: string } {
+  const today = new Date();
+
+  if (range === 'week') {
+    const end = new Date(today);
+    end.setDate(end.getDate() + 6);
+    return { stdate: fmt(today), eddate: fmt(end) };
+  }
+
+  if (range === 'month') {
+    const end = new Date(today.getFullYear(), today.getMonth() + 1, 0); // 이번 달 말일
+    return { stdate: fmt(today), eddate: fmt(end) };
+  }
+
+  // next-month
+  const start = new Date(today.getFullYear(), today.getMonth() + 1, 1); // 다음 달 1일
+  const end = new Date(today.getFullYear(), today.getMonth() + 2, 0);   // 다음 달 말일
+  return { stdate: fmt(start), eddate: fmt(end) };
+}

--- a/src/features/date-filter/index.ts
+++ b/src/features/date-filter/index.ts
@@ -1,0 +1,3 @@
+export { DateFilter } from './date-filter';
+export { getDateRangeParams } from './date-filter.utils';
+export type { DateRange } from './date-filter.utils';

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,3 +1,4 @@
 // 사용자 액션 (필터, 검색, 알림 등)
 export { GenreFilter } from "./genre-filter";
 export { RegionFilter, REGION_OPTIONS } from "./region-filter";
+export { DateFilter } from "./date-filter";

--- a/src/widgets/performance-list/performance-list.tsx
+++ b/src/widgets/performance-list/performance-list.tsx
@@ -12,6 +12,7 @@ import {
   GENRE_TO_KOPIS_CODE,
 } from "@/features/genre-filter";
 import { RegionFilter } from "@/features/region-filter";
+import { DateFilter, getDateRangeParams, type DateRange } from "@/features/date-filter";
 import type { FetchPerformancesParams } from "@/shared";
 
 // region이 바뀌어도 항상 고정 표시할 장르 목록
@@ -27,17 +28,20 @@ export function PerformanceList({ params }: Props) {
   const [page, setPage] = useState(1);
   const [selectedGenre, setSelectedGenre] = useState<string | null>(null);
   const [selectedRegion, setSelectedRegion] = useState<string | null>(null);
+  const [selectedDateRange, setSelectedDateRange] = useState<DateRange | null>(null);
 
   const queryParams = useMemo(
     () => ({
       ...params,
+      // 날짜 범위 선택 시 base params의 stdate/eddate를 덮어씀
+      ...(selectedDateRange && getDateRangeParams(selectedDateRange)),
       cpage: page,
       rows: PAGE_SIZE,
       ...(selectedRegion && { signgucode: selectedRegion }),
       // 장르 필터를 서버사이드로 전달 (클라이언트 필터링 대신 KOPIS shcate 사용)
       ...(selectedGenre && { shcate: GENRE_TO_KOPIS_CODE[selectedGenre] }),
     }),
-    [params, page, selectedRegion, selectedGenre],
+    [params, page, selectedRegion, selectedGenre, selectedDateRange],
   );
 
   const { data, isPending, error, isError } = usePerformances(queryParams);
@@ -62,6 +66,13 @@ export function PerformanceList({ params }: Props) {
 
   return (
     <div className="flex flex-1 flex-col">
+      <DateFilter
+        selected={selectedDateRange}
+        onChange={(range) => {
+          setSelectedDateRange(range);
+          setPage(1);
+        }}
+      />
       <RegionFilter
         selected={selectedRegion}
         onChange={(code) => {


### PR DESCRIPTION
## Summary
- DateFilter 컴포넌트: 전체 / 이번 주 / 이번 달 / 다음 달 버튼
- KOPIS `stdate`/`eddate` 파라미터를 서버사이드로 변경
- 날짜 선택 시 page=1 리셋

## Architecture
```
null(전체)    → base params 그대로 (3개월)
week          → today ~ today+6
month         → today ~ 이번 달 말일
next-month    → 다음 달 1일 ~ 말일
```

## Test plan
- [ ] 이번 주 선택 → 이번 주 공연만 표시 확인
- [ ] 다음 달 선택 → 다음 달 공연만 표시 확인
- [ ] 전체 선택 → 3개월치 공연 표시 확인
- [ ] 날짜 변경 시 페이지 1로 리셋 확인

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)