### PR TITLE
fix: shcate 파라미터 클라이언트→API route→KOPIS 전달 누락 수정

### DIFF
--- a/src/app/api/performances/route.ts
+++ b/src/app/api/performances/route.ts
@@ -12,6 +12,9 @@ export async function GET(request: Request) {
     ...(searchParams.get('signgucode') && {
       signgucode: searchParams.get('signgucode')!,
     }),
+    ...(searchParams.get('shcate') && {
+      shcate: searchParams.get('shcate')!,
+    }),
     ...(searchParams.get('prfstate') && {
       prfstate: searchParams.get(
         'prfstate',

--- a/src/shared/api/performances-client.ts
+++ b/src/shared/api/performances-client.ts
@@ -10,6 +10,7 @@ export async function fetchPerformancesClient(
     cpage: String(params.cpage ?? 1),
     rows: String(params.rows ?? 20),
     ...(params.signgucode && { signgucode: params.signgucode }),
+    ...(params.shcate && { shcate: params.shcate }),
     ...(params.prfstate && { prfstate: params.prfstate }),
   });
 


### PR DESCRIPTION
## Root Cause
genre 필터(`shcate`)가 두 곳에서 누락되어 KOPIS에 전달되지 않았음:
1. `performances-client.ts` → `/api/performances` 요청 시 URLSearchParams에 미포함
2. `route.ts` → searchParams에서 `shcate` 미파싱 → `fetchPerformances` 호출 시 누락

genre 단독으로 보이는 것은 해당 시기 장르 비율 편중 때문이며, 실제로는 필터가 동작하지 않는 상태였음

## Fix
두 파일에 `shcate` 처리 1줄씩 추가

## Test plan
- [ ] 뮤지컬 선택 → 뮤지컬만 표시 확인
- [ ] 뮤지컬 + 서울 → 서울 뮤지컬만 표시 확인
- [ ] 뮤지컬 + 이번 달 → 이번 달 뮤지컬만 표시 확인

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)