### PR TITLE
feat: save-user-preference

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -119,20 +119,29 @@
   - shared/lib/haversine.ts: haversineDistance(a, b) → km
   - ✅ 검증: 서울-부산 325.1km, 동일 좌표 0km
 
-- [ ] sort-by-distance
+- [x] sort-by-distance
   - 가까운 순 정렬
-  - ✅ 검증: 거리 기준 정렬
+  - features/sort-by-distance: sortByDistance(performances, userCoords)
+  - shared/lib/region-coords.ts: KOPIS area → 지역 중심 좌표 매핑
+  - "가까운 순" 토글 버튼 (위치 권한 요청 + 정렬 적용)
+  - ✅ 검증: 서울 기준 서울→부산→제주 순 정렬, 좌표불명 지역 후순위
 
 ---
 
 ## Phase 6: 알림
 
-- [ ] create-user-preference-table
-  - Supabase 테이블 생성
-  - ✅ 검증: 데이터 저장 가능
+- [x] create-user-preference-table
+  - Supabase user_preferences 테이블 생성
+  - supabase/migrations/20260404131237_create_user_preferences.sql
+  - 컬럼: id, email, genre, region, keyword, created_at
+  - email UNIQUE 인덱스, RLS 활성화 (public insert/select)
+  - ✅ 검증: INSERT/SELECT 정상 동작
 
-- [ ] save-user-preference
+- [x] save-user-preference
   - 관심 조건 저장
+  - POST /api/user-preferences → Supabase insert
+  - features/save-user-preference: 이메일 폼 (현재 필터 자동 전달)
+  - 중복 이메일 409 처리, 타입 에러 없음
   - ✅ 검증: DB 저장 성공
 
 - [ ] setup-cron-job

--- a/src/app/api/user-preferences/route.ts
+++ b/src/app/api/user-preferences/route.ts
@@ -1,0 +1,23 @@
+import { supabase } from '@/shared';
+import { NextResponse } from 'next/server';
+import type { UserPreferenceInsert } from '@/entities/user-preference';
+
+export async function POST(req: Request) {
+  const body: UserPreferenceInsert = await req.json();
+
+  if (!body.email || !body.email.includes('@')) {
+    return NextResponse.json({ error: '유효한 이메일을 입력해주세요.' }, { status: 400 });
+  }
+
+  const { error } = await supabase.from('user_preferences').insert(body);
+
+  if (error) {
+    // 이메일 중복 (unique constraint)
+    if (error.code === '23505') {
+      return NextResponse.json({ error: '이미 등록된 이메일입니다.' }, { status: 409 });
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -5,3 +5,4 @@ export { DateFilter } from "./date-filter";
 export { SearchInput } from "./search-input";
 export { useUserLocation } from "./user-location";
 export { sortByDistance } from "./sort-by-distance";
+export { SaveUserPreference } from "./save-user-preference";

--- a/src/features/save-user-preference/index.ts
+++ b/src/features/save-user-preference/index.ts
@@ -1,0 +1,1 @@
+export { SaveUserPreference } from './save-user-preference';

--- a/src/features/save-user-preference/save-user-preference.tsx
+++ b/src/features/save-user-preference/save-user-preference.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  genre: string | null;
+  region: string | null;
+  keyword: string;
+}
+
+// 현재 필터 조건을 이메일과 함께 저장하는 알림 등록 폼
+export function SaveUserPreference({ genre, region, keyword }: Props) {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('loading');
+
+    const res = await fetch('/api/user-preferences', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, genre, region, keyword: keyword || null }),
+    });
+
+    const data = await res.json();
+
+    if (res.ok) {
+      setStatus('success');
+      setMessage('알림 등록 완료! 새로운 공연이 생기면 알려드릴게요.');
+      setEmail('');
+    } else {
+      setStatus('error');
+      setMessage(data.error ?? '오류가 발생했습니다.');
+    }
+  };
+
+  return (
+    <div className='px-4 py-3 border-b border-border bg-brand/5'>
+      <p className='text-xs text-subtle mb-2'>현재 필터 조건으로 신규 공연 알림을 받아보세요.</p>
+      <form onSubmit={handleSubmit} className='flex gap-2'>
+        <input
+          type='email'
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder='이메일 입력'
+          required
+          disabled={status === 'loading' || status === 'success'}
+          className='flex-1 rounded-lg border border-border px-3 py-1.5 text-sm outline-none focus:border-brand disabled:opacity-50'
+        />
+        <button
+          type='submit'
+          disabled={status === 'loading' || status === 'success'}
+          className='rounded-lg bg-brand px-3 py-1.5 text-sm text-white disabled:opacity-50 hover:opacity-90'
+        >
+          {status === 'loading' ? '저장 중...' : '알림 받기'}
+        </button>
+      </form>
+      {message && (
+        <p className={`mt-1.5 text-xs ${status === 'success' ? 'text-brand' : 'text-error'}`}>
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/widgets/performance-list/performance-list.tsx
+++ b/src/widgets/performance-list/performance-list.tsx
@@ -16,6 +16,7 @@ import { DateFilter, getDateRangeParams, type DateRange } from "@/features/date-
 import { SearchInput } from "@/features/search-input";
 import { useUserLocation } from "@/features/user-location";
 import { sortByDistance } from "@/features/sort-by-distance";
+import { SaveUserPreference } from "@/features/save-user-preference";
 import { filterBtnClass } from "@/shared/ui/button-class";
 import { haversineDistance, REGION_COORDS } from "@/shared";
 import type { FetchPerformancesParams } from "@/shared";
@@ -187,6 +188,12 @@ export function PerformanceList({ params }: Props) {
           <span className="text-xs text-error">{locationError}</span>
         )}
       </div>
+
+      <SaveUserPreference
+        genre={selectedGenre}
+        region={selectedRegion}
+        keyword={searchQuery}
+      />
 
       {renderList()}
 


### PR DESCRIPTION
## Summary
- `POST /api/user-preferences` — Supabase insert, 중복 이메일 409 처리
- `features/save-user-preference` — 이메일 폼 컴포넌트 (현재 필터 자동 전달)
- `PerformanceList`에 통합, 현재 선택된 장르/지역/검색어 함께 저장

Closes #62

## Test plan
- [ ] 이메일 입력 후 "알림 받기" 클릭 → Supabase user_preferences에 행 INSERT 확인
- [ ] 동일 이메일 재등록 → "이미 등록된 이메일입니다." 에러 메시지 표시
- [ ] 장르/지역 필터 선택 후 등록 → genre/region 컬럼에 값 저장 확인
- [ ] 빈 이메일 제출 → 브라우저 validation으로 차단

🤖 Generated with [Claude Code](https://claude.com/claude-code)